### PR TITLE
feature/quickstart-yml-add

### DIFF
--- a/.quickstart/quickstart.yml
+++ b/.quickstart/quickstart.yml
@@ -1,0 +1,10 @@
+database_key: facebook_pages_database
+schema_key: facebook_pages_schema
+
+dbt_versions: ">=1.3.0 <2.0.0"
+
+destination_configurations:
+  databricks:
+    dispatch:
+      - macro_namespace: dbt_utils
+        search_order: [ 'spark_utils', 'dbt_utils' ]


### PR DESCRIPTION
This PR introduces the quickstart.yml for dbt_facebook_pages. This will not require a release or a version bump as this is only needed for the automated update process of Facebook Pages Quickstart data model.